### PR TITLE
chore: onDate limit in shipment

### DIFF
--- a/apps/app-fp-movement/src/screens/Shipment/ScanOrderScreen.tsx
+++ b/apps/app-fp-movement/src/screens/Shipment/ScanOrderScreen.tsx
@@ -87,6 +87,10 @@ const ScanOrderScreen = () => {
         setScannedObject(shipment);
         return;
       } else {
+        if (new Date(order.head.onDate).setHours(0, 0, 0, 0) < new Date().setHours(0, 0, 0, 0)) {
+          setScaner({ state: 'error', message: 'Нельзя выбрать дату меньше текущей' });
+          return;
+        }
         setScannedObject(order);
         setScaner({ state: 'found' });
       }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enforces a date constraint when scanning orders for shipment.
> 
> - In `ScanOrderScreen.tsx`, before creating a shipment, reject orders whose `head.onDate` (normalized to midnight) is earlier than today, setting scanner error "Нельзя выбрать дату меньше текущей" and aborting the flow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbf65ed3f6066ad0f54f430e87774cba2e10637c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->