### PR TITLE
chore: expeditor in routes, remains in orders

### DIFF
--- a/apps/app-trade-agents/src/screens/Orders/OrderEditScreen.tsx
+++ b/apps/app-trade-agents/src/screens/Orders/OrderEditScreen.tsx
@@ -47,6 +47,7 @@ const OrderEditScreen = () => {
     status: docStatus,
     comment: docComment,
     road: docRoad,
+    expeditor: docExpeditor,
   } = useSelector((state) => state.app.formParams as IOrderFormParam);
 
   // Подразделение по умолчанию
@@ -56,6 +57,7 @@ const OrderEditScreen = () => {
   const defaultDepart = useMemo(() => (isNamedEntity(departSetting) ? departSetting : undefined), [departSetting]);
   const outlet = refSelectors.selectByName<IOutlet>('outlet')?.data?.find((e) => e.id === docOutlet?.id);
   const road = refSelectors.selectByName<INamedEntity>('road')?.data;
+  const expeditor = refSelectors.selectByName<INamedEntity>('expeditors')?.data;
 
   useEffect(() => {
     if (!docContact && !!docOutlet) {
@@ -93,6 +95,7 @@ const OrderEditScreen = () => {
           depart: order.head.depart,
           comment: order.head.comment,
           road: order.head.road,
+          expeditor: order.head.expeditor,
         }),
       );
     } else {
@@ -113,6 +116,7 @@ const OrderEditScreen = () => {
         depart: defaultDepart,
         comment: undefined,
         road: undefined,
+        expeditor: undefined,
       };
 
       dispatch(appActions.setFormParams(road ? { ...formParams, road: undefined } : formParams));
@@ -155,6 +159,7 @@ const OrderEditScreen = () => {
             outlet: docOutlet,
             depart: docDepart,
             road: docRoad,
+            expeditor: docExpeditor,
             comment: docComment && docComment.trim(),
           },
           lines: [],
@@ -216,6 +221,7 @@ const OrderEditScreen = () => {
     road,
     docRoad,
     isUseRemains,
+    docExpeditor,
   ]);
 
   const renderRight = useCallback(
@@ -328,6 +334,18 @@ const OrderEditScreen = () => {
     });
   }, [docRoad, isBlocked, navigation]);
 
+  const handlePresentExpeditor = useCallback(() => {
+    if (isUseRemains ? docStatus !== 'DRAFT' : isBlocked) {
+      return;
+    }
+
+    navigation.navigate('SelectRefItem', {
+      refName: 'expeditors',
+      fieldName: 'expeditor',
+      value: docExpeditor && [docExpeditor],
+    });
+  }, [docExpeditor, docStatus, isBlocked, isUseRemains, navigation]);
+
   const handleChangeStatus = useCallback(() => {
     dispatch(appActions.setFormParams({ status: docStatus === 'DRAFT' ? 'READY' : 'DRAFT' }));
   }, [dispatch, docStatus]);
@@ -351,7 +369,6 @@ const OrderEditScreen = () => {
     return <AppActivityIndicator />;
   }
 
-  console.log('isUseRemains', isUseRemains);
   return (
     <AppInputScreen>
       <SubTitle>{statusName}</SubTitle>
@@ -383,7 +400,14 @@ const OrderEditScreen = () => {
         {road ? (
           <SelectableInput label="Маршрут" value={docRoad?.name} onPress={handlePresentRoad} disabled={isBlocked} />
         ) : null}
-
+        {expeditor ? (
+          <SelectableInput
+            label="Экспедитор"
+            value={docExpeditor?.name}
+            onPress={handlePresentExpeditor}
+            disabled={isUseRemains ? docStatus !== 'DRAFT' : isBlocked}
+          />
+        ) : null}
         <SelectableInput
           label="Склад-магазин"
           value={docDepart?.name}

--- a/apps/app-trade-agents/src/screens/Orders/components/OrderDepartDialog.tsx
+++ b/apps/app-trade-agents/src/screens/Orders/components/OrderDepartDialog.tsx
@@ -5,24 +5,30 @@ import { Button, Dialog, MD2Theme, useTheme } from 'react-native-paper';
 import { refSelectors } from '@lib/store';
 import { IDepartment, INamedEntity } from '@lib/types';
 
-import { TouchableOpacity, View } from 'react-native';
+import { TouchableOpacity, View, ScrollView, StyleSheet } from 'react-native';
 
 interface IProps {
   visible: boolean;
   onCancel: () => void;
-  onOk: (depart: INamedEntity) => void;
+  onOk: (depart: INamedEntity, expeditor?: INamedEntity) => void;
 }
 
 export const OrderDepartDialog = React.memo(({ onCancel, onOk, visible = false }: IProps) => {
   const { colors } = useTheme<MD2Theme>();
   const labelStyle = { color: colors.primary };
   const departmentList = refSelectors.selectByName<IDepartment>('department')?.data;
+
   const [visibleList, setVisibleList] = useState(false);
   const [depart, setDepart] = useState<IDepartment | undefined>(undefined);
 
+  const expeditorList = refSelectors.selectByName<IDepartment>('expeditors')?.data || [];
+
+  const [visibleEmployeeList, setVisibleEmployeeList] = useState(false);
+  const [expeditor, setExpeditor] = useState<INamedEntity | undefined>(undefined);
+
   return (
     <Dialog visible={visible} onDismiss={onCancel}>
-      <Dialog.Title style={styles.text18}>Выберите склад:</Dialog.Title>
+      <Dialog.Title style={styles.text18}>{expeditorList?.length ? 'Укажите данные:' : 'Выберите склад:'}</Dialog.Title>
       <>
         <Dialog.Content>
           <DropdownInput
@@ -32,22 +38,7 @@ export const OrderDepartDialog = React.memo(({ onCancel, onOk, visible = false }
             value={depart?.name || ''}
           />
           {visibleList && (
-            <View
-              style={{
-                marginTop: -13,
-                display: 'flex',
-                flexDirection: 'column',
-                marginHorizontal: 10,
-                /*fontSize: 17,*/
-                // paddingRight: 18,
-                // backgroundColor: colors.disabled,
-                overflow: 'scroll',
-                // maxHeight: 50,
-                borderColor: colors.primary,
-                borderRadius: 2,
-                borderWidth: 1,
-              }}
-            >
+            <View style={[localStyles.view, { borderColor: colors.primary }]}>
               {departmentList.map((item) => (
                 <View
                   key={item.id}
@@ -60,7 +51,7 @@ export const OrderDepartDialog = React.memo(({ onCancel, onOk, visible = false }
                       setDepart(item);
                       setVisibleList(false);
                     }}
-                    style={{ paddingLeft: 10, paddingVertical: 3 }}
+                    style={localStyles.dropdown}
                   >
                     <MediumText>{item.name}</MediumText>
                   </TouchableOpacity>
@@ -69,13 +60,46 @@ export const OrderDepartDialog = React.memo(({ onCancel, onOk, visible = false }
               ))}
             </View>
           )}
+          {expeditorList?.length ? (
+            <>
+              <DropdownInput
+                label="Экспедитор"
+                onPress={() => setVisibleEmployeeList(!visibleEmployeeList)}
+                isShownList={visibleEmployeeList}
+                value={expeditor?.name || ''}
+              />
+              {visibleEmployeeList && (
+                <ScrollView style={[localStyles.view, localStyles.employeeView, { borderColor: colors.primary }]}>
+                  {expeditorList.map((item) => (
+                    <View
+                      key={item.id}
+                      style={{
+                        backgroundColor: item.id === expeditor?.id ? colors.accent : '',
+                      }}
+                    >
+                      <TouchableOpacity
+                        onPress={() => {
+                          setExpeditor(item);
+                          setVisibleEmployeeList(false);
+                        }}
+                        style={localStyles.dropdown}
+                      >
+                        <MediumText>{item.name}</MediumText>
+                      </TouchableOpacity>
+                      <ItemSeparator />
+                    </View>
+                  ))}
+                </ScrollView>
+              )}
+            </>
+          ) : null}
         </Dialog.Content>
         <Dialog.Actions style={styles.columnAlignEnd}>
           <Button
             labelStyle={labelStyle}
             color={colors.primary}
             disabled={!depart}
-            onPress={() => depart && onOk(depart)}
+            onPress={() => (expeditor ? depart && onOk(depart, expeditor) : depart && onOk(depart))}
           >
             ОК
           </Button>
@@ -86,4 +110,21 @@ export const OrderDepartDialog = React.memo(({ onCancel, onOk, visible = false }
       </>
     </Dialog>
   );
+});
+
+const localStyles = StyleSheet.create({
+  employeeView: {
+    maxHeight: 150,
+  },
+  view: {
+    marginTop: -13,
+    display: 'flex',
+    flexDirection: 'column',
+    marginHorizontal: 10,
+    overflow: 'scroll',
+    borderRadius: 2,
+    borderWidth: 1,
+    maxHeight: 150,
+  },
+  dropdown: { paddingLeft: 10, paddingVertical: 3 },
 });

--- a/apps/app-trade-agents/src/screens/Orders/components/OrderLine.tsx
+++ b/apps/app-trade-agents/src/screens/Orders/components/OrderLine.tsx
@@ -95,9 +95,31 @@ const OrderLine = ({ item, packages, onSetLine }: IProps) => {
           </View>
         </View>
         <ItemSeparator />
+        {item.remains || item.remains === 0 ? (
+          <>
+            <View style={styles.item}>
+              <View style={styles.details}>
+                <Text style={styles.name}>Общий остаток</Text>
+                <Text style={textStyle}>{item.remains || 0}</Text>
+              </View>
+            </View>
+            <ItemSeparator />
+          </>
+        ) : null}
+        {item.agentRemains || item.agentRemains === 0 ? (
+          <>
+            <View style={styles.item}>
+              <View style={styles.details}>
+                <Text style={styles.name}>Остаток по агенту</Text>
+                <Text style={textStyle}>{item.agentRemains || 0}</Text>
+              </View>
+            </View>
+            <ItemSeparator />
+          </>
+        ) : null}
         <View style={styles.item}>
           <View style={styles.details}>
-            <Text style={styles.name}>Количество, кг</Text>
+            <Text style={styles.name}>Количество</Text>
             <TextInput
               style={[textStyle, localStyles.quantityItem]}
               showSoftInputOnFocus={false}

--- a/apps/app-trade-agents/src/screens/Orders/components/OrderLineEdit.tsx
+++ b/apps/app-trade-agents/src/screens/Orders/components/OrderLineEdit.tsx
@@ -23,9 +23,10 @@ export interface IOrderItemLine {
 interface IProps {
   orderLine: IOrderItemLine;
   onDismiss: () => void;
+  isUseRemains?: boolean;
 }
 
-const OrderLineEdit = ({ orderLine, onDismiss }: IProps) => {
+const OrderLineEdit = ({ orderLine, onDismiss, isUseRemains = false }: IProps) => {
   const dispatch = useDispatch();
   const { mode, item, docId } = orderLine;
 
@@ -46,6 +47,11 @@ const OrderLineEdit = ({ orderLine, onDismiss }: IProps) => {
     }
     if (line.quantity < 0) {
       Alert.alert('Ошибка!', 'Вес товара не может быть меньше нуля!', [{ text: 'Ок' }]);
+      setScreenState('idle');
+      return;
+    }
+    if (isUseRemains && line.remains && (line.remains <= 0 || line.remains - line.quantity < 0)) {
+      Alert.alert('Ошибка!', 'Остаток меньше 0!', [{ text: 'Ок' }]);
       setScreenState('idle');
       return;
     }
@@ -74,7 +80,7 @@ const OrderLineEdit = ({ orderLine, onDismiss }: IProps) => {
         { text: 'Отмена', onPress: () => setScreenState('idle') },
       ]);
     }
-  }, [dispatch, docId, line, mode, onDismiss, packages?.length]);
+  }, [dispatch, docId, isUseRemains, line, mode, onDismiss, packages?.length]);
 
   return (
     <Modal animationType="fade" visible={true}>

--- a/apps/app-trade-agents/src/screens/Remains/ContactListScreen.tsx
+++ b/apps/app-trade-agents/src/screens/Remains/ContactListScreen.tsx
@@ -9,7 +9,7 @@ import {
   SubTitle,
 } from '@lib/mobile-ui';
 import { refSelectors, useSelector } from '@lib/store';
-import { IDepartment, IReference } from '@lib/types';
+import { IDepartment, INamedEntity, IReference } from '@lib/types';
 import { useNavigation, useTheme } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
@@ -37,8 +37,9 @@ const ContactListScreen = () => {
 
   const remains = refSelectors.selectByName<IRemains>('remains')?.data[0];
   const department = refSelectors.selectByName<IDepartment>('department')?.data || [];
-  const contacts = department?.filter((i) => remains?.[i.id]);
-  console.log('contacts', contacts);
+  const employee = refSelectors.selectByName<INamedEntity>('employee')?.data || [];
+  const contacts = department?.concat(employee)?.filter((i) => remains?.[i.id]);
+
   const syncDate = useSelector((state) => state.app.syncDate);
 
   const filteredList = useMemo(() => {

--- a/apps/app-trade-agents/src/screens/Remains/components/GoodItem.tsx
+++ b/apps/app-trade-agents/src/screens/Remains/components/GoodItem.tsx
@@ -31,7 +31,8 @@ const GoodItem = ({ item }: IProps) => {
           <LargeText style={styles.textBold}>{item?.good.name}</LargeText>
           <View style={styles.directionRow}>
             <MediumText>
-              {item.remains} {item.good.valueName} / {(item?.priceFsn || 0).toString()} р.
+              {item.remains} {item.good.valueName} / {item.agentRemains} {item.good.valueName} /{' '}
+              {(item?.priceFsn || 0).toString()} р.
             </MediumText>
             {barcode && <MediumText style={[styles.number, styles.flexDirectionRow]}>{item.good.barcode}</MediumText>}
           </View>

--- a/apps/app-trade-agents/src/screens/Routes/VisitScreen.tsx
+++ b/apps/app-trade-agents/src/screens/Routes/VisitScreen.tsx
@@ -80,7 +80,7 @@ const VisitScreen = () => {
   const { colors } = useTheme<MD2Theme>();
 
   const visit = docSelectors.selectByDocType<IVisitDocument>('visit')?.find((e) => e.head.routeLineId === id);
-  console.log('visit', visit);
+
   const dateBegin = visit ? new Date(visit?.head.dateBegin) : undefined;
   const geo = visit?.head.beginGeoPoint;
   const [screenState, setScreenState] = useState<ScreenState>('idle');
@@ -189,6 +189,7 @@ const VisitScreen = () => {
 
   const [visibleDepartDialog, setVisibleDepartDialog] = useState(false);
   const [department, setDepartment] = useState<INamedEntity | undefined>(undefined);
+  const [expeditor, setExpeditor] = useState<INamedEntity | undefined>(undefined);
 
   useEffect(() => {
     const handleNewVisit = async () => {
@@ -258,14 +259,24 @@ const VisitScreen = () => {
           status: 'DRAFT',
           documentDate: newOrderDate,
           documentType: orderType,
-          head: {
-            contact,
-            outlet,
-            route,
-            onDate: newOnDate,
-            takenOrder: visit?.head.takenType,
-            depart: department ? department : defaultDepart,
-          },
+          head: expeditor
+            ? {
+                contact,
+                outlet,
+                route,
+                onDate: newOnDate,
+                takenOrder: visit?.head.takenType,
+                depart: department ? department : defaultDepart,
+                expeditor,
+              }
+            : {
+                contact,
+                outlet,
+                route,
+                onDate: newOnDate,
+                takenOrder: visit?.head.takenType,
+                depart: department ? department : defaultDepart,
+              },
           lines: [],
           creationDate: newOrderDate,
           editionDate: newOrderDate,
@@ -288,6 +299,7 @@ const VisitScreen = () => {
     defaultDepart,
     department,
     dispatch,
+    expeditor,
     id,
     isUseRemains,
     navigation,
@@ -541,9 +553,11 @@ const VisitScreen = () => {
       <OrderDepartDialog
         visible={visibleDepartDialog}
         onCancel={() => setVisibleDepartDialog(false)}
-        onOk={(depart: INamedEntity) => {
-          console.log('depart', depart);
+        onOk={(depart: INamedEntity, selectedExpeditor?: INamedEntity) => {
           setDepartment(depart);
+          if (selectedExpeditor) {
+            setExpeditor(selectedExpeditor);
+          }
           setVisibleDepartDialog(false);
           setScreenState('adding');
         }}

--- a/apps/app-trade-agents/src/store/app/types.ts
+++ b/apps/app-trade-agents/src/store/app/types.ts
@@ -86,6 +86,7 @@ export interface IRemains {
 export interface IRemainsData {
   goodId: string;
   q?: number;
+  qAgent?: number; // остатки по пользователю
   priceFso?: number;
   priceFsn?: number; // цена ФСН
   priceFsoSklad?: number; // цена ФСО склад
@@ -99,6 +100,7 @@ export interface IRemGood {
   priceFsoSklad: number; // цена ФСО склад
   priceFsnSklad: number; // цена ФСН склад
   remains: number;
+  agentRemains?: number; // остатки по агенту
 }
 
 export interface IModelRem {
@@ -107,4 +109,5 @@ export interface IModelRem {
   priceFsoSklad: number; // цена ФСО склад
   priceFsnSklad: number; // цена ФСН склад
   q: number;
+  qAgent?: number;
 }

--- a/apps/app-trade-agents/src/store/types.ts
+++ b/apps/app-trade-agents/src/store/types.ts
@@ -32,6 +32,7 @@ export interface IOrderFormParam extends IFormParam {
   route?: IReferenceData;
   road?: IReferenceData;
   comment?: string;
+  expeditor?: IReferenceData;
 }
 
 export interface IOrderListFormParam extends IFormParam {
@@ -168,12 +169,15 @@ export interface IOrderHead extends IHead {
   onDate: string; //  Дата отгрузки
   takenOrder?: TakeOrderType; //тип взятия заявки
   comment?: string;
+  expeditor?: IReferenceData; // экспедитор
 }
 
 export interface IOrderLine extends IEntity {
   good: IGood;
   quantity: number;
   package?: INamedEntity; // Вид упаковки
+  remains?: number;
+  agentRemains?: number;
 }
 
 export interface IOrderTotalLine {

--- a/apps/app-trade-agents/src/utils/helpers.ts
+++ b/apps/app-trade-agents/src/utils/helpers.ts
@@ -259,6 +259,7 @@ const getRemGoodListByContact = (
                 priceFso: good.priceFso,
                 priceFsoSklad: good.priceFsoSklad,
                 remains: r.q,
+                agentRemains: r.qAgent,
               });
             }
           }
@@ -270,13 +271,22 @@ const getRemGoodListByContact = (
             priceFso: good.priceFso,
             priceFsoSklad: good.priceFsoSklad,
             remains: 0,
+            agentRemains: 0,
           });
         }
       }
     } else if (!isRemains) {
       //Если по контакту нет остатков и выбор не из остатков, добавляем объект товара c 0
       for (const good of goods) {
-        remGoods.push({ good, priceFsn: 0, priceFsnSklad: 0, priceFso: 0, priceFsoSklad: 0, remains: 0 });
+        remGoods.push({
+          good,
+          priceFsn: 0,
+          priceFsnSklad: 0,
+          priceFso: 0,
+          priceFsoSklad: 0,
+          remains: 0,
+          agentRemains: 0,
+        });
       }
     }
   }
@@ -290,14 +300,14 @@ const getRemainsByGoodId = (remains: IRemainsData[], noZeroRemains = false) => {
   return remains.reduce(
     (
       p: IMGoodData<IModelRem[]>,
-      { goodId, priceFsn = 0, priceFsnSklad = 0, priceFso = 0, priceFsoSklad = 0, q = 0 }: IRemainsData,
+      { goodId, priceFsn = 0, priceFsnSklad = 0, priceFso = 0, priceFsoSklad = 0, q = 0, qAgent = 0 }: IRemainsData,
     ) => {
       const x = p[goodId];
       if (!noZeroRemains || q !== 0) {
         if (!x) {
-          p[goodId] = [{ priceFsn, priceFsnSklad, priceFso, priceFsoSklad, q }];
+          p[goodId] = [{ priceFsn, priceFsnSklad, priceFso, priceFsoSklad, q, qAgent }];
         } else {
-          x.push({ priceFsn, priceFsnSklad, priceFso, priceFsoSklad, q });
+          x.push({ priceFsn, priceFsnSklad, priceFso, priceFsoSklad, q, qAgent });
         }
       }
       return p;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds optional expeditor handling and enhances remains visibility and validation.
> 
> - Add `expeditor` to order form params and persist in `OrderEditScreen` and new order head; selectable input enabled when available
> - Extend `OrderDepartDialog` to pick both `department` and optional `expeditor`; refactor dropdown UI (scroll/styling)
> - In `VisitScreen`, capture dialog selections and include `expeditor` in created orders
> - Display remains: show `remains` and `agentRemains` in `OrderLine` and `GoodItem`
> - Enforce remains control in `OrderLineEdit` when `isUseRemains` (block save if quantity exceeds remains)
> - Types/helpers: add `qAgent`/`agentRemains` to app and order types; propagate via `getRemGoodListByContact`/`getRemainsByGoodId`
> - Remains contact list now includes `employee` references
> - Remove stray debug logs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c791510df296a544f7649cc3d5e275471a3c0ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->